### PR TITLE
Assorted fixes

### DIFF
--- a/compages/_common.py
+++ b/compages/_common.py
@@ -1,0 +1,66 @@
+from collections.abc import Callable, Generator
+from types import GeneratorType
+from typing import Any, ParamSpec
+
+P = ParamSpec("P")
+
+
+class GeneratorStack:
+    """
+    Maintains a stack of suspended continuations that take fixed arguments (``args``)
+    and a value, yield a value to use to create the next continuation,
+    and wait for the result of that continuation to be sent back to it.
+
+    The stack is unrolled as soon as a function returning a result and not a continuation is pushed.
+    """
+
+    def __init__(self, args: tuple[Any, ...], value: Any):
+        self._args = args
+        self._generators: list[Generator[Any, Any, Any]] = []
+        self._value = value
+        self._result = None
+
+    def push(self, func: None | Callable[P, Any]) -> bool:
+        """
+        Takes a function that takes the fixed ``args`` passed to the constructor
+        and the current ``value``, and either returns a result or a continuation.
+
+        If ``func`` is ``None``, no action is taken.
+
+        If the function returns a continuation, it is saved in the stack,
+        and the yielded value is saved to pass to the next function.
+        Returns ``False``.
+
+        If the function returns a result, the stack is unrolled by sending the result
+        to the last continuation, sending its result to the second to last continuation,
+        and so on.
+        Returns ``True``; the result can be queried from ``result()``.
+        """
+        if func is None:
+            return False
+
+        result = func(*self._args, self._value)
+
+        if isinstance(result, GeneratorType):
+            # Advance to the first `yield` and get the value to pass to the lower levels.
+            self._value = next(result)
+            self._generators.append(result)
+            return False
+
+        # Unroll the stack
+        for generator in reversed(self._generators):
+            try:
+                generator.send(result)
+            except StopIteration as exc:
+                result = exc.value
+                continue
+            raise RuntimeError("Expected only one yield in a generator")
+
+        self._result = result
+        return True
+
+    def result(self) -> Any:
+        return self._result
+
+    def is_empty(self) -> bool:
+        return not self._generators

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,12 @@ Changelog
 0.2.1 (2024-03-05)
 ------------------
 
+Added
+^^^^^
+
+- Skip fields equal to the defaults when unstructuring dataclasses. (PR_13_)
+
+
 Fixed
 ^^^^^
 
@@ -11,6 +17,7 @@ Fixed
 
 
 .. _PR_1: https://github.com/fjarri/compages/pull/1
+.. _PR_13: https://github.com/fjarri/compages/pull/13
 
 
 0.2.0 (2024-03-05)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,7 @@ Added
 ^^^^^
 
 - Skip fields equal to the defaults when unstructuring dataclasses. (PR_13_)
+- Generator-based deferring to lower level structuring and unstructuring. (PR_13_)
 
 
 Fixed

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,0 +1,49 @@
+import pytest
+from compages._common import GeneratorStack
+
+
+def test_normal_operation():
+    args = (1, 2)
+    stack = GeneratorStack(args, ["a"])
+
+    assert stack.is_empty()
+
+    # `None` is just ignored, and stack is not finalized
+    assert not stack.push(None)
+
+    def f1(arg1, arg2, val):
+        assert (arg1, arg2) == args
+        new_val = yield [*val, "b"]
+        return [*new_val, "c"]
+
+    # We pushed a generator, so the stack is not finalized yet
+    assert not stack.push(f1)
+
+    def f2(arg1, arg2, val):
+        assert (arg1, arg2) == args
+        return [*val, "d"]
+
+    # This is a normal function, so the stack is finalized and unrolled
+    assert stack.push(f2)
+    assert stack.result() == ["a", "b", "d", "c"]
+
+
+def test_multiple_yields():
+    args = (1, 2)
+    stack = GeneratorStack(args, ["a"])
+
+    def f1(arg1, arg2, val):
+        assert (arg1, arg2) == args
+        new_val = yield [*val, "b"]
+        new_val = yield [*new_val, "d"]
+        return [*val, "c"]
+
+    # We can't tell that there is a second yield until we start unrolling, so this passes
+    stack.push(f1)
+
+    def f2(arg1, arg2, val):
+        assert (arg1, arg2) == args
+        return [*val, "d"]
+
+    with pytest.raises(RuntimeError, match="Expected only one yield in a generator"):
+        stack.push(f2)


### PR DESCRIPTION
- Skip fields equal to the defaults when unstructuring dataclasses. Fixes #12
- Support generator-based handlers that can defer processing to more general handlers