### PR TITLE
Generalize lookup order in structuring/unstructuring

### DIFF
--- a/compages/__init__.py
+++ b/compages/__init__.py
@@ -1,5 +1,5 @@
 from ._structure import (
-    PredicateStructureHandler,
+    SequentialStructureHandler,
     Structurer,
     StructuringError,
 )
@@ -19,7 +19,7 @@ from ._structure_handlers import (
     structure_into_union,
 )
 from ._unstructure import (
-    PredicateUnstructureHandler,
+    SequentialUnstructureHandler,
     Unstructurer,
     UnstructuringError,
 )
@@ -40,10 +40,10 @@ from ._unstructure_handlers import (
 )
 
 __all__ = [
-    "PredicateStructureHandler",
+    "SequentialStructureHandler",
     "Structurer",
     "StructuringError",
-    "PredicateUnstructureHandler",
+    "SequentialUnstructureHandler",
     "StructureDictIntoDataclass",
     "StructureListIntoDataclass",
     "simple_structure",

--- a/compages/_structure_handlers.py
+++ b/compages/_structure_handlers.py
@@ -4,7 +4,7 @@ from functools import wraps
 from types import MappingProxyType
 from typing import Any, get_args
 
-from ._structure import PredicateStructureHandler, Structurer, StructuringError
+from ._structure import SequentialStructureHandler, Structurer, StructuringError
 from .path import DictKey, DictValue, ListElem, PathElem, StructField, UnionVariant
 
 
@@ -158,7 +158,7 @@ def structure_into_dict(structurer: Structurer, structure_into: type, val: Any) 
     return result
 
 
-class StructureListIntoDataclass(PredicateStructureHandler):
+class StructureListIntoDataclass(SequentialStructureHandler):
     def applies(self, structure_into: Any, val: Any) -> bool:
         return is_dataclass(structure_into) and isinstance(val, list)
 
@@ -190,7 +190,7 @@ class StructureListIntoDataclass(PredicateStructureHandler):
         return structure_into(**results)
 
 
-class StructureDictIntoDataclass(PredicateStructureHandler):
+class StructureDictIntoDataclass(SequentialStructureHandler):
     def __init__(
         self,
         name_converter: Callable[[str, MappingProxyType[Any, Any]], str] = lambda name,

--- a/compages/_unstructure.py
+++ b/compages/_unstructure.py
@@ -35,7 +35,7 @@ def collect_messages(
     return result
 
 
-class PredicateUnstructureHandler(ABC):
+class SequentialUnstructureHandler(ABC):
     @abstractmethod
     def applies(self, unstructure_as: Any, val: Any) -> bool: ...
 
@@ -46,27 +46,27 @@ class PredicateUnstructureHandler(ABC):
 class Unstructurer:
     def __init__(
         self,
-        handlers: Mapping[Any, Callable[["Unstructurer", Any, Any], Any]] = {},
-        predicate_handlers: Iterable[PredicateUnstructureHandler] = [],
+        lookup_handlers: Mapping[Any, Callable[["Unstructurer", Any, Any], Any]] = {},
+        sequential_handlers: Iterable[SequentialUnstructureHandler] = [],
     ):
-        self._handlers = dict(handlers)
-        self._predicate_handlers = list(predicate_handlers)
+        self._lookup_handlers = dict(lookup_handlers)
+        self._sequential_handlers = list(sequential_handlers)
 
     def unstructure_as(self, unstructure_as: Any, val: Any) -> Any:
         stack = GeneratorStack((self, unstructure_as), val)
         lookup_order = get_lookup_order(unstructure_as)
 
         for tp in lookup_order:
-            handler = self._handlers.get(tp, None)
+            handler = self._lookup_handlers.get(tp, None)
             if stack.push(handler):
                 return stack.result()
 
-        # Check all predicate handlers in order and see if there is one that applies
+        # Check all sequential handlers in order and see if there is one that applies
         # TODO (#10): should `applies()` raise an exception which we could collect
         # and attach to the error below, to provide more context on why no handlers were found?
-        for predicate_handler in self._predicate_handlers:
-            if predicate_handler.applies(unstructure_as, val):
-                if stack.push(predicate_handler):
+        for sequential_handler in self._sequential_handlers:
+            if sequential_handler.applies(unstructure_as, val):
+                if stack.push(sequential_handler):
                     return stack.result()
                 break
 

--- a/compages/_unstructure_handlers.py
+++ b/compages/_unstructure_handlers.py
@@ -4,7 +4,7 @@ from functools import wraps
 from types import MappingProxyType
 from typing import Any, get_args
 
-from ._unstructure import PredicateUnstructureHandler, Unstructurer, UnstructuringError
+from ._unstructure import SequentialUnstructureHandler, Unstructurer, UnstructuringError
 from .path import DictKey, DictValue, ListElem, PathElem, StructField, UnionVariant
 
 
@@ -156,7 +156,7 @@ def unstructure_as_list(unstructurer: Unstructurer, unstructure_as: type, val: l
     return result
 
 
-class UnstructureDataclassToDict(PredicateUnstructureHandler):
+class UnstructureDataclassToDict(SequentialUnstructureHandler):
     def __init__(
         self,
         name_converter: Callable[[str, MappingProxyType[Any, Any]], str] = lambda name,
@@ -191,7 +191,7 @@ class UnstructureDataclassToDict(PredicateUnstructureHandler):
         return result
 
 
-class UnstructureDataclassToList(PredicateUnstructureHandler):
+class UnstructureDataclassToList(SequentialUnstructureHandler):
     def applies(self, unstructure_as: Any, val: Any) -> bool:
         return is_dataclass(unstructure_as) and isinstance(val, unstructure_as)
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -13,8 +13,8 @@ Converters
 .. autoclass:: Unstructurer
    :members:
 
-.. autoclass:: PredicateStructureHandler
+.. autoclass:: SequentialStructureHandler
    :members:
 
-.. autoclass:: PredicateUnstructureHandler
+.. autoclass:: SequentialUnstructureHandler
    :members:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-0.2.1 (2024-03-05)
+0.3.0 (unreleased)
 ------------------
 
 Added
@@ -9,7 +9,15 @@ Added
 
 - Skip fields equal to the defaults when unstructuring dataclasses. (PR_13_)
 - Generator-based deferring to lower level structuring and unstructuring. (PR_13_)
+- Support for ``NewType`` chains. (PR_15_)
 
+
+.. _PR_13: https://github.com/fjarri/compages/pull/13
+.. _PR_15: https://github.com/fjarri/compages/pull/15
+
+
+0.2.1 (2024-03-05)
+------------------
 
 Fixed
 ^^^^^
@@ -18,7 +26,6 @@ Fixed
 
 
 .. _PR_1: https://github.com/fjarri/compages/pull/1
-.. _PR_13: https://github.com/fjarri/compages/pull/13
 
 
 0.2.0 (2024-03-05)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,12 @@ Changelog
 0.3.0 (unreleased)
 ------------------
 
+Changed
+^^^^^^^
+
+- Renamed "handlers" and "predicate handlers" to "lookup handlers" and "sequential handlers". (PR_15_)
+
+
 Added
 ^^^^^
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "compages"
-version = "0.2.1"
+version = "0.3.0-dev"
 description = "Modular structurer/unstructurer"
 authors = [
     {name = "Bogdan Opanchuk", email = "bogdan@opanchuk.net"},

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -69,4 +69,4 @@ def test_lookup_order():
     assert get_lookup_order(D) == [D, C, int]
     assert get_lookup_order(E) == [E, list[D], list]
     assert get_lookup_order(int | str) == [int | str, UnionType]
-    assert get_lookup_order(Union[int, str]) == [Union[int, str], Union] # noqa: UP007
+    assert get_lookup_order(Union[int, str]) == [Union[int, str], Union]  # noqa: UP007

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,5 +1,8 @@
+from types import UnionType
+from typing import NewType, Union
+
 import pytest
-from compages._common import GeneratorStack
+from compages._common import GeneratorStack, get_lookup_order
 
 
 def test_normal_operation():
@@ -47,3 +50,23 @@ def test_multiple_yields():
 
     with pytest.raises(RuntimeError, match="Expected only one yield in a generator"):
         stack.push(f2)
+
+
+def test_lookup_order():
+    class A:
+        pass
+
+    class B(A):
+        pass
+
+    C = NewType("C", int)
+    D = NewType("D", C)
+    E = NewType("E", list[D])
+
+    assert get_lookup_order(B) == [B, A]
+    assert get_lookup_order(list[A]) == [list[A], list]
+    assert get_lookup_order(C) == [C, int]
+    assert get_lookup_order(D) == [D, C, int]
+    assert get_lookup_order(E) == [E, list[D], list]
+    assert get_lookup_order(int | str) == [int | str, UnionType]
+    assert get_lookup_order(Union[int, str]) == [Union[int, str], Union] # noqa: UP007

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -65,13 +65,13 @@ def test_structure_routing():
         return val
 
     structurer = Structurer(
-        handlers={
+        lookup_handlers={
             int: structure_into_int,
             HexInt: structure_hex_int,
             list[int]: structure_custom_generic,
             list: structure_into_list,
         },
-        predicate_handlers=[StructureDictIntoDataclass()],
+        sequential_handlers=[StructureDictIntoDataclass()],
     )
 
     result = structurer.structure_into(
@@ -97,11 +97,11 @@ def test_structure_generators():
         return Container(x=from_lower_level.x * 2)
 
     structurer = Structurer(
-        handlers={
+        lookup_handlers={
             int: structure_into_int,
             Container: structure_container,
         },
-        predicate_handlers=[StructureDictIntoDataclass()],
+        sequential_handlers=[StructureDictIntoDataclass()],
     )
 
     assert structurer.structure_into(Container, {"x": 1}) == Container(x=22)
@@ -125,7 +125,7 @@ def test_structure_no_finalizing_handler():
             return new_val
 
     structurer = Structurer(
-        predicate_handlers=[MyStructureDataclass()],
+        sequential_handlers=[MyStructureDataclass()],
     )
 
     with pytest.raises(
@@ -156,14 +156,14 @@ def test_error_rendering():
         y: Inner
 
     structurer = Structurer(
-        handlers={
+        lookup_handlers={
             UnionType: structure_into_union,
             list: structure_into_list,
             dict: structure_into_dict,
             int: structure_into_int,
             str: structure_into_str,
         },
-        predicate_handlers=[StructureDictIntoDataclass()],
+        sequential_handlers=[StructureDictIntoDataclass()],
     )
 
     data = {"x": "a", "y": {"u": 1.2, "d": {"a": "b", 1: 2}, "lst": [1, "a"]}}

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -43,7 +43,7 @@ def assert_exception_matches(exc, reference_exc):
 
 
 def test_structure_routing():
-    # Test possible options for handling a given type.
+    # A smoke test for a combination of types requiring different handling.
 
     @dataclass
     class Container:

--- a/tests/test_structure_handlers.py
+++ b/tests/test_structure_handlers.py
@@ -35,7 +35,7 @@ def assert_exception_matches(exc, reference_exc):
 
 
 def test_structure_into_none():
-    structurer = Structurer(handlers={type(None): structure_into_none})
+    structurer = Structurer(lookup_handlers={type(None): structure_into_none})
     assert structurer.structure_into(type(None), None) is None
 
     with pytest.raises(StructuringError) as exc:
@@ -45,7 +45,7 @@ def test_structure_into_none():
 
 
 def test_structure_into_float():
-    structurer = Structurer(handlers={float: structure_into_float})
+    structurer = Structurer(lookup_handlers={float: structure_into_float})
     assert structurer.structure_into(float, 1.5) == 1.5
 
     # Specifically allow integers, but check that they are converted to floats.
@@ -60,7 +60,7 @@ def test_structure_into_float():
 
 
 def test_structure_into_bool():
-    structurer = Structurer(handlers={bool: structure_into_bool})
+    structurer = Structurer(lookup_handlers={bool: structure_into_bool})
     assert structurer.structure_into(bool, True) is True
     assert structurer.structure_into(bool, False) is False
 
@@ -71,7 +71,7 @@ def test_structure_into_bool():
 
 
 def test_structure_into_str():
-    structurer = Structurer(handlers={str: structure_into_str})
+    structurer = Structurer(lookup_handlers={str: structure_into_str})
     assert structurer.structure_into(str, "abc") == "abc"
 
     with pytest.raises(StructuringError) as exc:
@@ -81,7 +81,7 @@ def test_structure_into_str():
 
 
 def test_structure_into_bytes():
-    structurer = Structurer(handlers={bytes: structure_into_bytes})
+    structurer = Structurer(lookup_handlers={bytes: structure_into_bytes})
     assert structurer.structure_into(bytes, b"abc") == b"abc"
 
     with pytest.raises(StructuringError) as exc:
@@ -91,7 +91,7 @@ def test_structure_into_bytes():
 
 
 def test_structure_into_int():
-    structurer = Structurer(handlers={int: structure_into_int})
+    structurer = Structurer(lookup_handlers={int: structure_into_int})
     assert structurer.structure_into(int, 1) == 1
 
     with pytest.raises(StructuringError) as exc:
@@ -109,7 +109,11 @@ def test_structure_into_int():
 
 def test_structure_into_union():
     structurer = Structurer(
-        handlers={UnionType: structure_into_union, int: structure_into_int, str: structure_into_str}
+        lookup_handlers={
+            UnionType: structure_into_union,
+            int: structure_into_int,
+            str: structure_into_str,
+        }
     )
     assert structurer.structure_into(int | str, "a") == "a"
     assert structurer.structure_into(int | str, 1) == 1
@@ -128,7 +132,11 @@ def test_structure_into_union():
 
 def test_structure_into_tuple():
     structurer = Structurer(
-        handlers={tuple: structure_into_tuple, int: structure_into_int, str: structure_into_str}
+        lookup_handlers={
+            tuple: structure_into_tuple,
+            int: structure_into_int,
+            str: structure_into_str,
+        }
     )
 
     assert structurer.structure_into(tuple[()], []) == ()
@@ -161,7 +169,7 @@ def test_structure_into_tuple():
 
 
 def test_structure_into_list():
-    structurer = Structurer(handlers={list: structure_into_list, int: structure_into_int})
+    structurer = Structurer(lookup_handlers={list: structure_into_list, int: structure_into_int})
 
     assert structurer.structure_into(list[int], [1, 2, 3]) == [1, 2, 3]
     assert structurer.structure_into(list[int], (1, 2, 3)) == [1, 2, 3]
@@ -182,7 +190,11 @@ def test_structure_into_list():
 
 def test_structure_into_dict():
     structurer = Structurer(
-        handlers={dict: structure_into_dict, int: structure_into_int, str: structure_into_str}
+        lookup_handlers={
+            dict: structure_into_dict,
+            int: structure_into_int,
+            str: structure_into_str,
+        }
     )
 
     assert structurer.structure_into(dict[int, str], {1: "a", 2: "b"}) == {1: "a", 2: "b"}
@@ -213,8 +225,8 @@ def test_structure_into_dict():
 
 def test_structure_dataclass_from_list():
     structurer = Structurer(
-        handlers={int: structure_into_int, str: structure_into_str},
-        predicate_handlers=[StructureListIntoDataclass()],
+        lookup_handlers={int: structure_into_int, str: structure_into_str},
+        sequential_handlers=[StructureListIntoDataclass()],
     )
 
     @dataclass
@@ -250,8 +262,8 @@ def test_structure_dataclass_from_list():
 
 def test_structure_dataclass_from_dict():
     structurer = Structurer(
-        handlers={int: structure_into_int, str: structure_into_str},
-        predicate_handlers=[
+        lookup_handlers={int: structure_into_int, str: structure_into_str},
+        sequential_handlers=[
             StructureDictIntoDataclass(name_converter=lambda name, _metadata: name + "_")
         ],
     )
@@ -287,8 +299,8 @@ def test_structure_dataclass_from_dict():
 
     # Need a structurer without a name converter for this one
     structurer = Structurer(
-        handlers={int: structure_into_int, str: structure_into_str},
-        predicate_handlers=[StructureDictIntoDataclass()],
+        lookup_handlers={int: structure_into_int, str: structure_into_str},
+        sequential_handlers=[StructureDictIntoDataclass()],
     )
     with pytest.raises(StructuringError) as exc:
         structurer.structure_into(Container, {"x": 1, "z": "b"})

--- a/tests/test_unstructure.py
+++ b/tests/test_unstructure.py
@@ -61,13 +61,13 @@ def test_unstructure_routing():
         return val
 
     unstructurer = Unstructurer(
-        handlers={
+        lookup_handlers={
             int: unstructure_as_int,
             HexInt: unstructure_as_hex_int,
             list[int]: unstructure_as_custom_generic,
             list: unstructure_as_list,
         },
-        predicate_handlers=[UnstructureDataclassToDict()],
+        sequential_handlers=[UnstructureDataclassToDict()],
     )
 
     result = unstructurer.unstructure_as(
@@ -91,11 +91,11 @@ def test_unstructure_generators():
         return {"x": from_lower_level["x"] * 2}
 
     unstructurer = Unstructurer(
-        handlers={
+        lookup_handlers={
             int: unstructure_as_int,
             Container: unstructure_container,
         },
-        predicate_handlers=[UnstructureDataclassToDict()],
+        sequential_handlers=[UnstructureDataclassToDict()],
     )
 
     assert unstructurer.unstructure_as(Container, Container(x=1)) == {"x": 22}
@@ -119,7 +119,7 @@ def test_unstructure_no_finalizing_handler():
             return new_val
 
     unstructurer = Unstructurer(
-        predicate_handlers=[MyUnstructureDataclass()],
+        sequential_handlers=[MyUnstructureDataclass()],
     )
 
     with pytest.raises(
@@ -150,14 +150,14 @@ def test_error_rendering():
         y: Inner
 
     unstructurer = Unstructurer(
-        handlers={
+        lookup_handlers={
             UnionType: unstructure_as_union,
             list: unstructure_as_list,
             dict: unstructure_as_dict,
             int: unstructure_as_int,
             str: unstructure_as_str,
         },
-        predicate_handlers=[UnstructureDataclassToDict()],
+        sequential_handlers=[UnstructureDataclassToDict()],
     )
 
     data = Outer(x="a", y=Inner(u=1.2, d={"a": "b", 1: 2}, lst=[1, "a"]))

--- a/tests/test_unstructure.py
+++ b/tests/test_unstructure.py
@@ -41,7 +41,7 @@ def unstructure_as_hex_int(val):
 
 
 def test_unstructure_routing():
-    # Test possible options for handling a given type.
+    # A smoke test for a combination of types requiring different handling.
 
     @dataclass
     class Container:

--- a/tests/test_unstructure_handlers.py
+++ b/tests/test_unstructure_handlers.py
@@ -36,7 +36,7 @@ def assert_exception_matches(exc, reference_exc):
 
 
 def test_unstructure_as_none():
-    unstructurer = Unstructurer(handlers={type(None): unstructure_as_none})
+    unstructurer = Unstructurer(lookup_handlers={type(None): unstructure_as_none})
     assert unstructurer.unstructure_as(type(None), None) is None
 
     with pytest.raises(UnstructuringError) as exc:
@@ -46,7 +46,7 @@ def test_unstructure_as_none():
 
 
 def test_unstructure_as_float():
-    unstructurer = Unstructurer(handlers={float: unstructure_as_float})
+    unstructurer = Unstructurer(lookup_handlers={float: unstructure_as_float})
     assert unstructurer.unstructure_as(float, 1.5) == 1.5
 
     with pytest.raises(UnstructuringError) as exc:
@@ -56,7 +56,7 @@ def test_unstructure_as_float():
 
 
 def test_unstructure_as_bool():
-    unstructurer = Unstructurer(handlers={bool: unstructure_as_bool})
+    unstructurer = Unstructurer(lookup_handlers={bool: unstructure_as_bool})
     assert unstructurer.unstructure_as(bool, True) is True
     assert unstructurer.unstructure_as(bool, False) is False
 
@@ -67,7 +67,7 @@ def test_unstructure_as_bool():
 
 
 def test_unstructure_as_str():
-    unstructurer = Unstructurer(handlers={str: unstructure_as_str})
+    unstructurer = Unstructurer(lookup_handlers={str: unstructure_as_str})
     assert unstructurer.unstructure_as(str, "abc") == "abc"
 
     with pytest.raises(UnstructuringError) as exc:
@@ -77,7 +77,7 @@ def test_unstructure_as_str():
 
 
 def test_unstructure_as_bytes():
-    unstructurer = Unstructurer(handlers={bytes: unstructure_as_bytes})
+    unstructurer = Unstructurer(lookup_handlers={bytes: unstructure_as_bytes})
     assert unstructurer.unstructure_as(bytes, b"abc") == b"abc"
 
     with pytest.raises(UnstructuringError) as exc:
@@ -87,7 +87,7 @@ def test_unstructure_as_bytes():
 
 
 def test_unstructure_as_int():
-    unstructurer = Unstructurer(handlers={int: unstructure_as_int})
+    unstructurer = Unstructurer(lookup_handlers={int: unstructure_as_int})
     assert unstructurer.unstructure_as(int, 1) == 1
 
     with pytest.raises(UnstructuringError) as exc:
@@ -105,7 +105,11 @@ def test_unstructure_as_int():
 
 def test_unstructure_as_union():
     unstructurer = Unstructurer(
-        handlers={UnionType: unstructure_as_union, int: unstructure_as_int, str: unstructure_as_str}
+        lookup_handlers={
+            UnionType: unstructure_as_union,
+            int: unstructure_as_int,
+            str: unstructure_as_str,
+        }
     )
     assert unstructurer.unstructure_as(int | str, "a") == "a"
     assert unstructurer.unstructure_as(int | str, 1) == 1
@@ -124,7 +128,11 @@ def test_unstructure_as_union():
 
 def test_unstructure_as_tuple():
     unstructurer = Unstructurer(
-        handlers={tuple: unstructure_as_tuple, int: unstructure_as_int, str: unstructure_as_str}
+        lookup_handlers={
+            tuple: unstructure_as_tuple,
+            int: unstructure_as_int,
+            str: unstructure_as_str,
+        }
     )
 
     assert unstructurer.unstructure_as(tuple[()], []) == []
@@ -157,7 +165,9 @@ def test_unstructure_as_tuple():
 
 
 def test_unstructure_as_list():
-    unstructurer = Unstructurer(handlers={list: unstructure_as_list, int: unstructure_as_int})
+    unstructurer = Unstructurer(
+        lookup_handlers={list: unstructure_as_list, int: unstructure_as_int}
+    )
 
     assert unstructurer.unstructure_as(list[int], [1, 2, 3]) == [1, 2, 3]
     assert unstructurer.unstructure_as(list[int], (1, 2, 3)) == [1, 2, 3]
@@ -178,7 +188,11 @@ def test_unstructure_as_list():
 
 def test_unstructure_as_dict():
     unstructurer = Unstructurer(
-        handlers={dict: unstructure_as_dict, int: unstructure_as_int, str: unstructure_as_str}
+        lookup_handlers={
+            dict: unstructure_as_dict,
+            int: unstructure_as_int,
+            str: unstructure_as_str,
+        }
     )
 
     assert unstructurer.unstructure_as(dict[int, str], {1: "a", 2: "b"}) == {1: "a", 2: "b"}
@@ -209,8 +223,8 @@ def test_unstructure_as_dict():
 
 def test_unstructure_dataclass_to_dict():
     unstructurer = Unstructurer(
-        handlers={int: unstructure_as_int, str: unstructure_as_str},
-        predicate_handlers=[
+        lookup_handlers={int: unstructure_as_int, str: unstructure_as_str},
+        sequential_handlers=[
             UnstructureDataclassToDict(name_converter=lambda name, _metadata: name + "_")
         ],
     )
@@ -274,14 +288,14 @@ def test_unstructure_dataclass_to_dict_skip_defaults():
         return "B"
 
     unstructurer = Unstructurer(
-        handlers={
+        lookup_handlers={
             UnionType: unstructure_as_union,
             A: unstructure_a,
             B: unstructure_b,
             int: unstructure_as_int,
             str: unstructure_as_str,
         },
-        predicate_handlers=[UnstructureDataclassToDict()],
+        sequential_handlers=[UnstructureDataclassToDict()],
     )
 
     # `y` will not be present in the results since its value is equal to the default one
@@ -293,8 +307,8 @@ def test_unstructure_dataclass_to_dict_skip_defaults():
 
 def test_unstructure_dataclass_to_list():
     unstructurer = Unstructurer(
-        handlers={int: unstructure_as_int, str: unstructure_as_str},
-        predicate_handlers=[UnstructureDataclassToList()],
+        lookup_handlers={int: unstructure_as_int, str: unstructure_as_str},
+        sequential_handlers=[UnstructureDataclassToList()],
     )
 
     @dataclass


### PR DESCRIPTION
- Move all lookup order logic into `_common.get_lookup_order()`
- Add support for calling handlers for base classes
- Add support for `NewType` chains - fixes #3